### PR TITLE
Add support for reading passphrases from stdin

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -4,22 +4,30 @@
 
 const assert = require('bsert');
 const {StringDecoder} = require('string_decoder');
+const readline = require('readline');
 
 async function readLine(prefix = '', secret = false) {
   assert(typeof prefix === 'string');
   assert(typeof secret === 'boolean');
 
-  const {stdin, stdout} = process;
+  const {stdin} = process;
+
+  if (!stdin.isTTY || !secret)
+    return readLineUnmasked(prefix);
+
+  return readLineMasked(prefix);
+}
+
+async function readLineMasked(prefix = '') {
   const decoder = new StringDecoder('utf8');
-
-  let out = '';
-
+  const {stdin, stdout} = process;
   stdin.setRawMode(true);
   stdin.resume();
 
   if (prefix)
     stdout.write(`${prefix}: `);
 
+  let out = '';
   return new Promise((resolve, reject) => {
     const cleanup = () => {
       stdin.removeListener('error', onError);
@@ -54,8 +62,6 @@ async function readLine(prefix = '', secret = false) {
 
         case 0x7f: { // Backspace
           if (out.length > 0) {
-            if (!secret)
-              stdout.write('\x1b[D \x1b[D');
             out = out.slice(0, -1);
           }
           break;
@@ -66,12 +72,7 @@ async function readLine(prefix = '', secret = false) {
         }
 
         default: {
-          const str = decoder.write(data);
-
-          if (!secret)
-            stdout.write(str, 'utf8');
-
-          out += str;
+          out += decoder.write(data);
 
           if (out.length > 4096) {
             cleanup();
@@ -85,6 +86,40 @@ async function readLine(prefix = '', secret = false) {
 
     stdin.on('error', onError);
     stdin.on('data', onData);
+  });
+}
+
+async function readLineUnmasked(prompt = '') {
+  const {stdin, stdout} = process;
+  stdin.resume();
+  stdin.setEncoding('utf-8');
+
+  return await new Promise((resolve, reject) => {
+    const hdlr = (passphrase) => {
+      if (passphrase.length > 4096)
+        return reject(new Error('String too long.'));
+
+      resolve(passphrase);
+    };
+
+    if (stdin.isTTY) {
+      const rl = readline.createInterface({
+        input: stdin,
+        output: stdout,
+      });
+      rl.question(prompt ? `${prompt}: ` : '', hdlr);
+      return;
+    }
+
+    let res = '';
+    stdin.on('readable', () => {
+      let chunk;
+      while ((chunk = stdin.read())) {
+        res += chunk;
+      }
+    });
+
+    stdin.on('end', () => hdlr(res));
   });
 }
 


### PR DESCRIPTION
Hi there,

I'm looking at calling this utility from the command line, where a separate process provides the user's SSH passphrase via stdin outside of a TTY. This pull request adds support for that use case.