### PR TITLE
Repair ED25519 key loading.

### DIFF
--- a/lib/key.js
+++ b/lib/key.js
@@ -724,9 +724,9 @@ class AirdropKey extends bio.Struct {
       }
 
       case ssh.keyTypes.ED25519: {
-        assert(pk.point.length === 32);
+        assert(pk.key.length === 32);
         this.type = keyTypes.ED25519;
-        this.point = pk.point;
+        this.point = pk.key;
         break;
       }
 


### PR DESCRIPTION
I'm guessing `bcrypto` must have changed something out from under you. Without this patch, trying to use the airdrop with an ED25519 key gives:

```
mac:hs-airdrop kousu$ ./bin/hs-airdrop ~/.ssh/id_ed25519 [address] 0.5 --bare
Passphrase: 
TypeError: Cannot read property 'length' of undefined
    at AirdropKey.fromSSH (/Users/kousu/src/hs-airdrop/lib/key.js:727:25)
    at Function.fromSSH (/Users/kousu/src/hs-airdrop/lib/key.js:851:23)
    at readKey (/Users/kousu/src/hs-airdrop/bin/hs-airdrop:414:25)
    at processTicksAndRejections (internal/process/next_tick.js:81:5)
```

with it I get:


```
mac:hs-airdrop kousu$ ./bin/hs-airdrop ~/.ssh/id_ed25519 [address] 0.5 --bare
Passphrase: 
Attempting to create proof.
This may take a bit...
Downloading: https://github.com/handshake-org/hs-tree-data/raw/master/tree.bin...
Decrypting nonce...
Downloading: https://github.com/handshake-org/hs-tree-data/raw/master/nonces/076.bin...
Error: Could not find nonce in bucket 76.
    at findNonce (/Users/kousu/src/hs-airdrop/bin/hs-airdrop:235:9)
```