### PR TITLE
Remove Broken ECDSA SSH Pubkey Validation

### DIFF
--- a/lib/key.js
+++ b/lib/key.js
@@ -711,8 +711,6 @@ class AirdropKey extends bio.Struct {
       case ssh.keyTypes.P256: {
         const point = pk.point || p256.publicKeyCreate(pk.key);
 
-        assert(point.length === 32);
-
         this.type = keyTypes.P256;
         this.point = p256.publicKeyConvert(point, true);
 


### PR DESCRIPTION
Hi, I finally got around to running this tool on an old ECDSA key. The pubkey bcypto generates actually has variable length depending on the actual point, so it isn't *always* exactly 32 bytes.

My pubkey:
`ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBB1dd1iYG9DZhM5rDVDiQXev9v4Rj98SfM9OxReIN7AWxT87SzDFCv8K9x3LY3M4c1/wRztcNIYuK/KLjhGP8Lo=`

Gets represented as `<Buffer 02 1d 5d 77 58 98 1b d0 d9 84 ce 6b 0d 50 e2 41 77 af f6 fe 11 8f df 12 7c cf 4e c5 17 88 37 b0 16>` (**33** bytes).

With this change in the validation, everything works fine and a valid proof is generated.

We could possibly want some upper bound, but I'm not entirely sure what that should be and don't really see that it's necessary. **This same check is also applied to `ED25519` and may not be valid there either**, but I'm sure about the details of the point compression.