### PR TITLE
hs-airdrop: Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node
+COPY . .
+ENV BUILD_DIR hs-tree-data
+RUN npm i & git clone https://github.com/handshake-org/hs-tree-data.git
+ENTRYPOINT ["./bin/hs-airdrop"]


### PR DESCRIPTION
Address #17 
We've already an [image on the namebase Docker Hub](https://hub.docker.com/r/namebase/hs-airdrop), but it would be nice if there were an official `handshake-org` build. Someone with access to the `handshake-org` GitHub account can add a Docker Hub integration that, and automatically builds and publishes an image on every update to `master` and maybe any update to https://github.com/handshake-org/hs-tree-data (though, that have to be manually triggered)

This is method is nicer because:
1. It doesn't require installing the right version of node/npm/etc
2. `hs-airdrop` is run in a completely un-networked container with read-only access to a single private key.

```
docker pull <namebase OR handshake-org>/hs-airdrop && docker run -it --network none -v ~/.ssh/<id_github>:/private_key:ro <namebase OR handshake-org>/hs-airdrop private_key <address> <fee>
```