### PR TITLE
bin: verbose error for missing nonce

### DIFF
--- a/bin/hs-airdrop
+++ b/bin/hs-airdrop
@@ -271,8 +271,13 @@ async function findNonces(key, priv) {
     }
   }
 
-  if (out.length === 0)
-    throw new Error(`Could not find nonce in bucket ${bucket}.`);
+  if (out.length === 0) {
+    console.log(`Could not find nonce in bucket ${bucket}.`);
+    console.log('This means your key was not found in the airdrop tree.');
+    console.log('If you registered at handshake.org, use that address.');
+    console.log('Usage: $ hs-airdrop [addr]');
+    process.exit(1);
+  }
 
   return out;
 }


### PR DESCRIPTION
Closes #21 and replaces #22.

200,000 people are about to try and use this program, this output is extremely likely and support requests are very common already.

example:
```
$ bin/hs-airdrop ~/.ssh/id_rsa hs1q7q3h4chglps004u3yn79z0cp9ed24rfr5ka9n5
Passphrase: 
Attempting to create proof.
This may take a bit.
Decrypting nonce...
Could not find nonce in bucket 200.
This means your key was not found in the airdrop tree.
If you registed at handshake.org for a faucet airdrop,
your coins are at that address instead:
$ hs-airdrop [addr]
```