### PR TITLE
github: issue template with FAQ

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+Frequently Opened Issues:
+
+"Error: Nonce not found in bucket..."
+
+Your key is not in the airdrop tree.
+You must have had >=15 followers on GitHub on Feb 4, 2019
+AND you must have had a PGP or SSH public key associated with your account.
+
+If you ALSO signed up for the faucet at handshake.org during 2018 and submitted
+an address, your GitHub keys were removed from the airdrop tree. Use the seed
+phrase you generated for the faucet to receive your airdrop.
+
+"Error: Invalid Checksum"
+
+You need to re-install the latest version of hs-airdrop.
+You may also need to clear old data that was saved on your computer
+at ~/.hs-tree-data
+
+PLEASE check the README and other issues both open and closed for your question.
+
+If none of this information helps, please proceed with your issue.
+-->


### PR DESCRIPTION
Apparently we need to blast the FAQ out of every available orifice. (sorry).

So here's a github issue template with the FAQ.

You can try it out on my own repo where the default branch is currently set to this PR:

https://github.com/pinheadmz/hs-airdrop/issues/new