### PR TITLE
github: add tree-data errors to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,6 +17,14 @@ You need to re-install the latest version of hs-airdrop.
 You may also need to clear old data that was saved on your computer
 at ~/.hs-tree-data
 
+"Error: connect ECONNREFUSED / ETIMEDOUT / ECONNRESET"
+
+There was a problem downloading the tree data from GitHub.
+You can try again in a few minutes, or manually download the data.
+It should be installed in your home directory, for example:
+
+git clone https://github.com/handshake-org/hs-tree-data ~/.hs-tree-data
+
 PLEASE check the README and other issues both open and closed for your question.
 
 If none of this information helps, please proceed with your issue.


### PR DESCRIPTION
Network errors are another FAQ, sometimes the tree data doesn't download on the first try.

See #86 #82 #56 #53 #52 #37 