### PR TITLE
Fix the ending char checking condition

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -45,6 +45,7 @@ async function readLine(prefix = '', secret = false) {
 
         case 0x03: // ^C
         case 0x04: // ^D
+        case 0x0a: // <LF>
         case 0x0d: { // <CR>
           cleanup();
           stdout.write('\n');


### PR DESCRIPTION
For windows, we will get LFCR when we press ENTER. In your logic, you only check the `data[0]`, so it's LR for windows.
Or maybe you could change the switch condition here not just use `data[0]`.